### PR TITLE
Add all rank options to the rank filtering.

### DIFF
--- a/FiveOhFirstDataCore.Core/Structures/RosterSearch.cs
+++ b/FiveOhFirstDataCore.Core/Structures/RosterSearch.cs
@@ -16,7 +16,7 @@ namespace FiveOhFirstDataCore.Core.Structures
         public string NickNameFilter { get; set; } = "";
 
         public bool UseRankSearch { get; set; } = false;
-        public TrooperRank? RankFilter { get; set; } = null;
+        public int? RankFilter { get; set; } = null;
         public string RankSearch { get; set; } = "";
 
         public bool UseUnitSearch { get; set; } = false;

--- a/FiveOhFirstDataCore.Pages/Roster/RosterListing.razor
+++ b/FiveOhFirstDataCore.Pages/Roster/RosterListing.razor
@@ -32,8 +32,29 @@
                         <option value="null">Rank</option>
                         @foreach(TrooperRank r in Enum.GetValues(typeof(TrooperRank)))
                         {
-                            <option value="@r">@r.AsFull()</option>
+                            <option value="@((int)r)">@r.AsFull()</option>
                         }
+                        @foreach(MedicRank r in Enum.GetValues(typeof(MedicRank)))
+                        {
+                            <option value="@((int)r)">@r.AsFull()</option>
+                        }
+                        @foreach(RTORank r in Enum.GetValues(typeof(RTORank)))
+                        {
+                            <option value="@((int)r)">@r.AsFull()</option>
+                        }
+                        @foreach(WarrantRank r in Enum.GetValues(typeof(WarrantRank)))
+                        {
+                            <option value="@((int)r)">@r.AsFull()</option>
+                        }
+                        @foreach(PilotRank r in Enum.GetValues(typeof(PilotRank)))
+                        {
+                            <option value="@((int)r)">@r.AsFull()</option>
+                        }
+                        @foreach(WardenRank r in Enum.GetValues(typeof(WardenRank)))
+                        {
+                            <option value="@((int)r)">@r.AsFull()</option>
+                        }
+
                     </InputSelect>
                     <button class="oi oi-text btn input-group-text" @onclick="(x) => Search.UseRankSearch = true" aria-hidden="true"></button>
                 }
@@ -199,7 +220,39 @@
         {
             if(Search.RankFilter is not null)
             {
-                Filtered = Filtered.Where(x => x.Rank == Search.RankFilter).ToList();   
+                Filtered = Filtered.Where(x =>
+                {
+                    int Rank = (int)Search.RankFilter;
+                    
+                    if (Rank < 100)
+                    {
+                        return x.Rank == (TrooperRank)Rank;                    
+                    }
+                    else if (Rank >= 100 && Rank < 200)
+                    {
+                    return x.MedicRank == (MedicRank)Rank;
+                    }
+                    else if (Rank >= 200 && Rank < 300)
+                    {
+                        return x.RTORank == (RTORank)Rank;
+                    }
+                    else if (Rank >= 300 && Rank < 400)
+                    {
+                        return x.WarrantRank == (WarrantRank)Rank;
+                    }
+                    else if (Rank >= 400 && Rank < 500)
+                    {
+                        return x.PilotRank == (PilotRank)Rank;
+                    }
+                    else if (Rank >= 500)
+                    {
+                        return x.WardenRank == (WardenRank)Rank;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }).ToList();   
             }
         }
 
@@ -348,9 +401,9 @@
     public Task OnRankChange(ChangeEventArgs e)
     {
         var val = ((string?)e.Value) ?? "";
-
+        
         if(val == "null") Search.RankFilter = null;
-        else Search.RankFilter = val.ValueFromString<TrooperRank>();
+        else Search.RankFilter = Int32.Parse(val);
 
         return BuildFilteredList();
     }

--- a/FiveOhFirstDataCore.Pages/Roster/RosterListing.razor
+++ b/FiveOhFirstDataCore.Pages/Roster/RosterListing.razor
@@ -230,7 +230,7 @@
                     }
                     else if (Rank >= 100 && Rank < 200)
                     {
-                    return x.MedicRank == (MedicRank)Rank;
+                        return x.MedicRank == (MedicRank)Rank;
                     }
                     else if (Rank >= 200 && Rank < 300)
                     {


### PR DESCRIPTION
# Describe the PR
Add all rank options to the rank filtering.

# Implements
Implements #141 

# Changes Made
 - Change the type of `RankFilter` on the `RosterSearch` structure from `TrooperRank` to `int`
 - Add all ranks to the Rank filter dropdown
 - Make Rank Filter filter by all ranks
 - Update `OnRankChange` to use `int` instead of `TrooperRank`