### PR TITLE
Fix Razor pilot requiring a team.

### DIFF
--- a/FiveOhFirstDataCore.Core/Data/Roster/Orbat/RazorFlightData.cs
+++ b/FiveOhFirstDataCore.Core/Data/Roster/Orbat/RazorFlightData.cs
@@ -6,19 +6,22 @@ namespace FiveOhFirstDataCore.Core.Data.Roster
     {
         public Trooper Commander { get; set; }
         public RazorSectionData[] Sections { get; set; } = new RazorSectionData[] { new(), new() };
-
+        
         public void Assign(Trooper t)
         {
-            switch (t.Team)
+            if (t.Role == Role.Commander)
             {
-                case null:
-                    if (t.Role == Role.Commander)
-                        Commander = t;
-                    break;
-                case Team.Alpha:
+                Commander = t;
+                return;
+            }
+            // Convert the slot to a double value based on flight number
+            var val = (double)decimal.Round((decimal)t.Slot / 10 % 10 % 1, 1);
+            switch (val)
+            {
+                case 0.1:
                     Sections[0].Assign(t);
                     break;
-                case Team.Bravo:
+                case 0.2:
                     Sections[1].Assign(t);
                     break;
             }


### PR DESCRIPTION
# Describe the PR
Fix Razor pilot requiring a team.

# Implements
Implements #153 

# Changes Made
Change the implementation of `Assign` on `RazorFlightData` to assign based off of slot instead of team.