### PR TITLE
Fix Mission Builder Builder bug.

### DIFF
--- a/FiveOhFirstDataCore.Pages/Data/PublicTrooperProfile.razor
+++ b/FiveOhFirstDataCore.Pages/Data/PublicTrooperProfile.razor
@@ -95,7 +95,15 @@
                                             <ul class="mb-1">
                                             @foreach(var pos in positions)
                                             {
-                                                <li class="mb-1">@pos.Key @pos.Value</li>
+                                                if(@pos.Value != "Builder")
+                                                {
+                                                    <li class="mb-1">@pos.Key @pos.Value</li>
+                                                }
+                                                else
+                                                {
+                                                    <li class="mb-1">@pos.Key</li>
+                                                }
+
                                             }
                                             </ul>
                                         }


### PR DESCRIPTION
# Describe the PR
Make the C Shop display `Mission Builder` instead of `Mission Builder Builder`

# Implements
Implements #68

# Changes Made
Check if `pos.Value` is not `Builder`, if it is not then display as normal, if it is then only display `pos.Key`