### PR TITLE
fixed pending promotions being filtered out of Eligible promotions

### DIFF
--- a/FiveOhFirstDataCore.Core/Services/IWebsiteSettingsService.cs
+++ b/FiveOhFirstDataCore.Core/Services/IWebsiteSettingsService.cs
@@ -29,9 +29,11 @@ namespace FiveOhFirstDataCore.Core.Services
         /// <param name="forTrooper">The <see cref="Trooper"/> to get promotions for.</param>
         /// <param name="filterOutTrooperToWarrant">A <see cref="bool"/> indicating if this action should 
         /// filter out promtions into a <see cref="WarrantRank"/></param>
+        /// <param name="filterOutPendingPromotions">A <see cref="bool"/> indicating if this action should 
+        /// filter out current pending promotions.</param>
         /// <returns>A <see cref="Task"/> that returns <see cref="IReadOnlyList{T}"/> of 
         /// type <see cref="Promotion"/> for a <see cref="Trooper"/></returns>
-        public Task<IReadOnlyList<Promotion>> GetEligiblePromotionsAsync(Trooper forTrooper, bool filterOutTrooperToWarrant = false);
+        public Task<IReadOnlyList<Promotion>> GetEligiblePromotionsAsync(Trooper forTrooper, bool filterOutTrooperToWarrant = false, bool filterOutPendingPromotions = true);
         /// <summary>
         /// Get the saved promotion details from the database.
         /// </summary>

--- a/FiveOhFirstDataCore.Pages/Promotions/PendingPromotionsListing.razor
+++ b/FiveOhFirstDataCore.Pages/Promotions/PendingPromotionsListing.razor
@@ -123,7 +123,7 @@
 
                 if(set.Count() > 0)
                 {
-                    var eligible = await _settings.GetEligiblePromotionsAsync(t);
+                    var eligible = await _settings.GetEligiblePromotionsAsync(t,false,false);
                     foreach(var i in set)
                     {
                         if(!eligible.Any(x => x.PromoteFrom == i.PromoteFrom 


### PR DESCRIPTION
# Describe the PR
fixes Forced promotions not displaying normally once Eligible.

# Closes
Closes #208 

# Changes Made
Describe your changes in detail here:
1. added bool `filterOutPendingPromotions param` to `GetEligiblePromotionsAsync`
2. added If statement based on `filterOutPendingPromotions`.
3. added param to `GetEligiblePromotionsAsync` call in `PendingPromotionsListing`
