### PR TITLE
Revert dependency

### DIFF
--- a/FiveOhFirstDataCore.Core/FiveOhFirstDataCore.Core.csproj
+++ b/FiveOhFirstDataCore.Core/FiveOhFirstDataCore.Core.csproj
@@ -9,10 +9,10 @@
     <PackageReference Include="DSharpPlus" Version="4.1.0" />
     <PackageReference Include="DSharpPlus.Rest" Version="4.1.0" />
     <PackageReference Include="Lucene.Net.Analysis.Phonetic" Version="4.8.0-beta00014" />
-    <PackageReference Include="MailKit" Version="2.14.0" />
-    <PackageReference Include="Markdig" Version="0.25.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.0-preview.6.21355.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.0-preview.6.21355.2" />
+    <PackageReference Include="MailKit" Version="2.15.0" />
+    <PackageReference Include="Markdig" Version="0.26.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.0-preview.7.21378.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.0-preview.7.21378.6" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0-preview6" />
   </ItemGroup>
 

--- a/FiveOhFirstDataCore.Core/Services/RosterService.cs
+++ b/FiveOhFirstDataCore.Core/Services/RosterService.cs
@@ -570,6 +570,7 @@ namespace FiveOhFirstDataCore.Core.Services
             if (manager || (slot >= Slot.Mynock && slot <= Slot.MynockOneThree))
             {
                 var data = new MynockSectionData();
+            var data = new MynockSectionData();
 
                 using var _dbContext = _dbContextFactory.CreateDbContext();
 

--- a/FiveOhFirstDataCore.Core/Services/RosterService.cs
+++ b/FiveOhFirstDataCore.Core/Services/RosterService.cs
@@ -570,7 +570,6 @@ namespace FiveOhFirstDataCore.Core.Services
             if (manager || (slot >= Slot.Mynock && slot <= Slot.MynockOneThree))
             {
                 var data = new MynockSectionData();
-            var data = new MynockSectionData();
 
                 using var _dbContext = _dbContextFactory.CreateDbContext();
 

--- a/FiveOhFirstDataCore.Pages/FiveOhFirstDataCore.Pages.csproj
+++ b/FiveOhFirstDataCore.Pages/FiveOhFirstDataCore.Pages.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.0-preview.6.21355.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.0-preview.7.21378.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FiveOhFirstDataCore/FiveOhFirstDataCore.csproj
+++ b/FiveOhFirstDataCore/FiveOhFirstDataCore.csproj
@@ -28,17 +28,17 @@
 
   <ItemGroup>
     <PackageReference Include="AspNet.Security.OpenId.Steam" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.0-preview.6.21355.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.0-preview.6.21355.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.0-preview.6.21355.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.0-preview.6.21355.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0-preview.6.21352.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.0-preview.6.21352.1">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.0-preview.7.21378.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.0-preview.7.21378.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.0-preview.7.21378.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.0-preview.7.21378.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0-preview.7.21378.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.0-preview.7.21378.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.0-preview.6.21352.12" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.0-preview.7.21377.19" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0-preview.7.21413.1" />
   </ItemGroup>
 

--- a/FiveOhFirstDataCore/FiveOhFirstDataCore.csproj
+++ b/FiveOhFirstDataCore/FiveOhFirstDataCore.csproj
@@ -28,18 +28,18 @@
 
   <ItemGroup>
     <PackageReference Include="AspNet.Security.OpenId.Steam" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.0-rc.1.21452.15" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.0-rc.1.21452.15" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.0-rc.1.21452.15" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.0-rc.1.21452.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0-rc.1.21452.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.0-rc.1.21452.10">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.0-preview.6.21355.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.0-preview.6.21355.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.0-preview.6.21355.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.0-preview.6.21355.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0-preview.6.21352.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.0-preview.6.21352.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.0-rc.1.21451.13" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0-rc.1.21464.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.0-preview.6.21352.12" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0-preview.7.21413.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Describe the PR
Accidentally Updated Dependency packages to RC-1 which broke the build in #218.
Updated packages gave a 
```
Method 'AppendIdentityWhereCondition' in type 
'Npgsql.EntityFrameworkCore.PostgreSQL.Update.Internal.Npgsql Update Sql Generator'
from assembly 
'Npgsql.EntityFrameworkCore.PostgreSQL, Version=6.0.0.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7'
does not have an implementation.
```


# Changes Made
Describe your changes in detail here:
1. Reverted https://github.com/501stLegionA3/FiveOhFirstDataCore/commit/7bf35401dc4b04aa883696977b38c12bf7b90dc4
2. Reimplemented fix to `GetMynockSectionDataAsync` in `RosterSerive`