### PR TITLE
Make edit trooper load claims tree when directly going to edit page

### DIFF
--- a/FiveOhFirstDataCore/Pages/Personnel/Roster/EditTrooper.razor
+++ b/FiveOhFirstDataCore/Pages/Personnel/Roster/EditTrooper.razor
@@ -928,6 +928,7 @@
                 {
                     Trooper = first;
                     CShopClaims = await _roster.GetCShopClaimsAsync(Trooper);
+                    ClaimsTree = await _settings.GetFullClaimsTreeAsync();
                 }
             }
 


### PR DESCRIPTION
# Describe the PR
Make edit trooper load claims tree when directly going to edit page

# Changes Made
Add `ClaimsTree = await _settings.GetFullClaimsTreeAsync();` to `OnAfterRenderAsync` in `EditTrooper.razor`
