### PR TITLE
Change display value for quals in PublicTrooperProfile

### DIFF
--- a/FiveOhFirstDataCore.Pages/Data/PublicTrooperProfile.razor
+++ b/FiveOhFirstDataCore.Pages/Data/PublicTrooperProfile.razor
@@ -81,7 +81,7 @@
         <div class="qual">
                 @foreach(var qual in QualValues)
                 {
-                    <p>@qual</p>
+                    <p>@qual.AsFull()</p>
                 }
             </div>
       </div>


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Describe the PR
Changes display value for qualifications in the trooper profile

# Closes
Closes #245

# Changes Made
Make the display for quals call `AsFull` to get the description value

# Notes
Any other notes go here.
