### PR TITLE
Reversed TiG and TiS, Fixes #247

### DIFF
--- a/FiveOhFirstDataCore.Pages/Data/PublicTrooperProfile.razor.cs
+++ b/FiveOhFirstDataCore.Pages/Data/PublicTrooperProfile.razor.cs
@@ -59,10 +59,10 @@ namespace FiveOhFirstDataCore.Components.Data
                 ShopPositions = await _roster.GetCShopClaimsAsync(Trooper);
 
                 var now = DateTime.UtcNow.ToEst();
-                ServiceStrings[0] = Trooper.LastPromotion.ToShortDateString();
-                ServiceStrings[2] = Trooper.StartOfService.ToShortDateString();
-                ServiceStrings[1] = now.Subtract(Trooper.LastPromotion).TotalDays.ToString("F0");
-                ServiceStrings[3] = now.Subtract(Trooper.StartOfService).TotalDays.ToString("F0");
+                ServiceStrings[0] = Trooper.StartOfService.ToShortDateString();
+                ServiceStrings[1] = now.Subtract(Trooper.StartOfService).TotalDays.ToString("F0");
+                ServiceStrings[2] = Trooper.LastPromotion.ToShortDateString();
+                ServiceStrings[3] = now.Subtract(Trooper.LastPromotion).TotalDays.ToString("F0");
                 ServiceStrings[4] = Trooper.LastBilletChange.ToShortDateString();
                 ServiceStrings[5] = now.Subtract(Trooper.LastBilletChange).TotalDays.ToString("F0");
 


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Describe the PR
See Issue #247 , TiG and TiS were reversed, Fixed by switching the order of the TiS and TiG datapoints.


# Closes
Closes #247 

# Changes Made
Describe your changes in detail here:
1. Moved TiS, Date Joined to index 0, 1, and TiG and Last Promoted to 2, 3 respectively to match the webpage.
2. Formatted data to numerical order

